### PR TITLE
Fixed regexp pattern problem

### DIFF
--- a/src/bidi/bidi.clj
+++ b/src/bidi/bidi.clj
@@ -132,6 +132,8 @@
   (unmatch-pattern [this m]
     (apply str (map #(unmatch-segment % (:params m)) this)))
 
+  ;;(match-route [[#"(.*)" :path] 'doit'] "foo-bar")
+
   Keyword
   (match-pattern [this env] (when (= this (:request-method env)) env))
   (unmatch-pattern [_ _] "")

--- a/test/bidi/bidi_test.clj
+++ b/test/bidi/bidi_test.clj
@@ -55,6 +55,9 @@
            {:handler 'foo :params {:id "123"}}))
 
     (testing "regex"
+      (is (= (match-route [[#"(.*)" :path] 'foo] "/blog/articles")
+             {:handler 'foo :params {:path "/blog/articles"}}))
+
       (is (= (match-route ["/blog" [[["/articles/" [#"\d+" :id] "/index.html"] 'foo]
                                     ["/text" 'bar]]]
                           "/blog/articles/123/index.html")


### PR DESCRIPTION
- Previously, the `match-segment` fn for Keywords would lose the last character of a capture for wildcard-like matches/params: [#"(.*)" :path]
- Added test
