### PR TITLE
Fixed problem with regexp/param matching

### DIFF
--- a/src/bidi/bidi.clj
+++ b/src/bidi/bidi.clj
@@ -49,7 +49,7 @@
 
   Keyword
   ;; By default, a keyword can represent any string.
-  (match-segment [_] "([^/]+)")
+  (match-segment [_] "([^/]*)")
   (unmatch-segment [this params]
     (if-let [v (this params)]
       (str v)

--- a/test/bidi/bidi_test.clj
+++ b/test/bidi/bidi_test.clj
@@ -55,6 +55,8 @@
            {:handler 'foo :params {:id "123"}}))
 
     (testing "regex"
+      (is (= (match-route [[#"(.*)" :path] 'foo] "/blog/articles")
+             {:handler 'foo :params {:path "/blog/articles"}}))
       (is (= (match-route ["/blog" [[["/articles/" [#"\d+" :id] "/index.html"] 'foo]
                                     ["/text" 'bar]]]
                           "/blog/articles/123/index.html")


### PR DESCRIPTION
- Previously, the last char of a regexp match group would be lost - this change fixes that
- Added test
