### PR TITLE
Fix typo in Name Begins With section

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,13 @@ There are numerous Clojure routing libraries. Here's a table to help you compare
 <td>Yes</td>
 </tr>
 <tr>
-<td>Name begins with a B?</td>
-<td>No</td>
-<td>No</td>
-<td>No</td>
+<td>Name begins with a R?</td>
 <td>No</td>
 <td>No</td>
 <td>Yes!</td>
+<td>No</td>
+<td>No</td>
+<td>No</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
Hi Malcolm,

In `Comparison with other routing libraries`, there's a typo: most likely you've meant `Begins with R`, not `Begins with B`.

Word such as `rocket`, `rabbitmq` start with `R`, whereas `B` is the first letter for `bad` and `boring`. R is really superior to B.
