### PR TITLE
Middleware uses :path-info as well as :uri

### DIFF
--- a/src/bidi/bidi.clj
+++ b/src/bidi/bidi.clj
@@ -300,8 +300,9 @@
   it with the request as a parameter."
   [route]
   (assert route "Cannot create a Ring handler with a nil Route(s) parameter")
-  (fn [{:keys [uri] :as request}]
-    (let [{:keys [handler params]} (apply match-route route uri (apply concat (seq request)))]
+  (fn [{:keys [uri path-info] :as request}]
+    (let [path (or path-info uri)
+          {:keys [handler params]} (apply match-route route path (apply concat (seq request)))]
       (when handler
         (handler (-> request (assoc :route-params params)))))))
 

--- a/test/bidi/bidi_test.clj
+++ b/test/bidi/bidi_test.clj
@@ -212,6 +212,10 @@
             {:uri "/index.html"})
            {:wrapper :evidence :status 200 :body "Test"}))
 
+    (is (= ((:handler (match-route ["/index.html" (->WrapMiddleware handler wrapper)] "/index.html"))
+            {:path-info "/index.html"})
+           {:wrapper :evidence :status 200 :body "Test"}))
+
     (is (= (path-for ["/index.html" (->WrapMiddleware handler wrapper)] handler) "/index.html"))
     (is (= (path-for ["/index.html" handler] handler) "/index.html"))))
 


### PR DESCRIPTION
- When running a Ring app in a servlet environment, :uri contains the full path of the app – which includes the servlet base path. This causes problems with route matching when your root route starts with / – because bidi currently only uses :uri. The :path-info value on the other hand, is the path, but without the servlet base path.
- This is similar to what Ring already does with the path-info fn here: https://github.com/ring-clojure/ring/blob/1d74427381b2861639033ab80007b6bbef1be508/ring-core/src/ring/util/request.clj#L54
- Added simple test
