### PR TITLE
New functionality "path-with-query-for" where additional params are form encoded

### DIFF
--- a/test/bidi/bidi_test.clj
+++ b/test/bidi/bidi_test.clj
@@ -269,3 +269,13 @@
       (is (= (handler (-> (request :put "/blog/user/8888/article")
                           (assoc :params {"foo" "bar"})))
              {:status 201 :body {:userid "8888"}})))))
+
+(deftest path-with-query-for-test
+  (let [routes [["/blog/user/" :userid "/article"] :index]]
+
+    (is (= (path-with-query-for routes :index :userid 123)
+           "/blog/user/123/article"))
+    (is (= (path-with-query-for routes :index :userid 123 :page 1)
+           "/blog/user/123/article?page=1"))
+    (is (= (path-with-query-for routes :index :userid 123 :page 1 :foo "bar")
+           "/blog/user/123/article?foo=bar&page=1"))))


### PR DESCRIPTION
Constructing a url using path-for is not completely agnostic of the routing logic if you need to know which parameters are required in the route and which may be used as a query parameter.

This change adds a function "path-with-query-for" which appends additional parameters as form encoded query parameters to the url.

It also exposes "route-params" which can tell you what the required route parameters are for a given handler.
