### PR TITLE
Support clojure/clojurescript UUIDs via bidi.bidi/uuid function

### DIFF
--- a/test/bidi/bidi_test.cljx
+++ b/test/bidi/bidi_test.cljx
@@ -199,3 +199,29 @@
 
     (testing "bigger than longs"
       (is (nil? (match-route routes "/foo/1012301231111111111111111111"))))))
+
+(deftest uuid-test
+  (let [routes ["/" [["foo/" :x]
+                     [["foo/" [bidi/uuid :id]] :y]
+                     [["foo/" [bidi/uuid :id] "/bar"] :z]]]]
+    (is (= (:handler (match-route routes "/foo/")) :x))
+    (is (= #{} (route-params routes :x)))
+
+    (is (= (:handler (match-route routes "/foo/649a50e8-0342-47af-894e-27eefea83ca9"))
+           :y))
+    (is (= (:route-params (match-route routes "/foo/649a50e8-0342-47af-894e-27eefea83ca9"))
+           {:id #uuid "649a50e8-0342-47af-894e-27eefea83ca9"}))
+    (is (= (path-for routes :y :id #uuid "649a50e8-0342-47af-894e-27eefea83ca9")
+           "/foo/649a50e8-0342-47af-894e-27eefea83ca9"))
+    (is (= #{:id} (route-params routes :y)))
+
+    (is (= (:handler (match-route routes "/foo/649a50e8-0342-47af-894e-27eefea83ca9/bar")) :z))
+    (is (= (path-for routes :z :id #uuid "649a50e8-0342-47af-894e-27eefea83ca9")
+           "/foo/649a50e8-0342-47af-894e-27eefea83ca9/bar"))
+    (is (= #{:id} (route-params routes :z)))
+    
+    (testing "invalid uuids"
+      (is (nil? (match-route routes "/foo/649a50e8-0342-67af-894e-27eefea83ca9")))
+      (is (nil? (match-route routes "/foo/649a50e8-0342-47af-c94e-27eefea83ca9")))
+      (is (nil? (match-route routes "/foo/649a50e8034247afc94e27eefea83ca9")))
+      (is (nil? (match-route routes "/foo/1012301231111111111111111111"))))))


### PR DESCRIPTION
While `keyword` and `long` are extremely useful for matching route parameters, it would be great to have UUID support (particularly for anyone using datomic squuids as external identifiers in favour of `:db/id`). Sadly clojure / clojurescript core only support UUID literals - there is no (public) core function that I can find for constructing the UUID type appropriate to the platform from a string input, so this patch adds both clojure and clojurescript support for doing so via the `bidi.bidi/uuid` function, which can be used in route patterns in the same way as `keyword` and `long`.

The regex used for UUIDs is fairly conservative - it allows only version 1-5 UUIDs with a specification compliant variant. This is actually somewhat more conservative than the UUIDs allowed by java.util.UUID, so it may be more appropriate to relax the regex to simply be:

`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`

Thanks for bidi!
