### PR TITLE
Making 'Resources' return a handler when the resource isn't found, not a response

### DIFF
--- a/src/bidi/ring.clj
+++ b/src/bidi/ring.clj
@@ -63,7 +63,7 @@
                      (-> (fn [req] (url-response res))
                          (wrap-file-info (:mime-types options))
                          (wrap-content-type options))
-                     {:status 404})))))
+                     (fn [req] {:status 404}))))))
   (unresolve-handler [this m] nil))
 
 (defn resources [options]


### PR DESCRIPTION
When a resource isn't found, the existing functionality just returns a response map in place of a handler, which then returns nil when passed a request. 

This PR ensures that the `:handler` key is always a valid handler, regardless of whether the resource is found.

James