### PR TITLE
Bump coordinates to match project.clj / clojars

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ HTTP servers (including Jetty, [http-kit](http://http-kit.org/) and
 Add the following dependency to your `project.clj` file
 
 ```clojure
-[bidi "1.12.0"]
+[bidi "1.15.0"]
 ```
 
 ## Take 5 minutes to learn bidi (using the REPL)


### PR DESCRIPTION
Hi, seems like the lein coordinates haven't been updated with the last couple of releases.

Thanks!