### PR TITLE
rewrite performance 'tests' to use criterium

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,7 @@
 (defproject bidi "1.15.0"
   :description "Bidirectional URI routing"
   :url "https://github.com/juxt/bidi"
+
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
 
@@ -33,7 +34,13 @@
                                     :rules :clj}
                                    {:source-paths ["test"]
                                     :output-path "target/generated/test/cljs"
-                                    :rules :cljs}]}}}
+                                    :rules :cljs}]}}
+             :bench
+             {:jvm-opts ^:replace ["-server" "-XX:+AggressiveOpts" "-XX:+UseFastAccessorMethods" "-Djava.awt.headless=true"]
+              :test-paths ["bench"]
+              :dependencies [[criterium "0.4.3"]
+                             [ring-mock "0.1.5"]
+                             [compojure "1.1.6"]]}}
 
   :aliases {"deploy" ["do" "clean," "cljx" "once," "deploy" "clojars"]
             "test" ["do" "clean," "cljx" "once," "test," "with-profile" "dev" "cljsbuild" "test"]}


### PR DESCRIPTION
Measuring benchmark results with `time` is **terribly confusing** on the JVM. I downloaded this project and ran the perf tests, and managed to get *wildly* differing results upon each run. Criterium (or something of its ilk) should be used instead, for more repeatable results.

Secondly, this project was running "benchmarks" with leiningen's default JVM options, which are optimized for startup time (see https://github.com/technomancy/leiningen/wiki/Faster), not performance. This PR creates a new profile `bench`, which replaces the default `lein` jvm options with reasonably optimized ones.

Criterium results from running on my machine:

```
lein test bidi.perf-test
Time to match using Compojure's routes
WARNING: Final GC required 1.520699241780737 % of runtime
Evaluation count : 14886480 in 60 samples of 248108 calls.
             Execution time mean : 4.369460 µs
    Execution time std-deviation : 1.039080 µs
   Execution time lower quantile : 3.704490 µs ( 2.5%)
   Execution time upper quantile : 7.198565 µs (97.5%)
                   Overhead used : 2.154800 ns

Found 8 outliers in 60 samples (13.3333 %)
        low-severe       4 (6.6667 %)
        low-mild         4 (6.6667 %)
 Variance from outliers : 92.9322 % Variance is severely inflated by outliers
Time to match using uncompiled bidi routes
Evaluation count : 3060900 in 60 samples of 51015 calls.
             Execution time mean : 20.889797 µs
    Execution time std-deviation : 2.021276 µs
   Execution time lower quantile : 18.338725 µs ( 2.5%)
   Execution time upper quantile : 24.613728 µs (97.5%)
                   Overhead used : 2.154800 ns

Found 3 outliers in 60 samples (5.0000 %)
        low-severe       2 (3.3333 %)
        low-mild         1 (1.6667 %)
 Variance from outliers : 68.6370 % Variance is severely inflated by outliers
Time to match using compiled bidi routes
Evaluation count : 4300200 in 60 samples of 71670 calls.
             Execution time mean : 13.786776 µs
    Execution time std-deviation : 1.873523 µs
   Execution time lower quantile : 12.027941 µs ( 2.5%)
   Execution time upper quantile : 17.929625 µs (97.5%)
                   Overhead used : 2.154800 ns

Found 4 outliers in 60 samples (6.6667 %)
        low-severe       1 (1.6667 %)
        low-mild         3 (5.0000 %)
 Variance from outliers : 80.7262 % Variance is severely inflated by outliers

Ran 2 tests containing 5 assertions.
0 failures, 0 errors.
```