### PR TITLE
add to travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+sudo: false
+language: clojure
+lein: lein2
+cache:
+  directories:
+    - $HOME/.m2


### PR DESCRIPTION
sets up a `.travis.yml` so tests run on travis-ci. You'll have to turn it on via the webapp (https://travis-ci.org/profile/juxt) to make tests run (as I understand travis anyway)