### PR TITLE
Fix make-handler broken by 1.17.0

### DIFF
--- a/src/bidi/ring.clj
+++ b/src/bidi/ring.clj
@@ -26,17 +26,17 @@
   it with the request as a parameter."
   ([route handler-fn]
       (assert route "Cannot create a Ring handler with a nil Route(s) parameter")
-      (fn [{:keys [uri path-info] :as request}]
+      (fn [{:keys [uri path-info] :as req}]
         (let [path (or path-info uri)
               {:keys [handler route-params] :as match-context}
-              (apply match-route route path (apply concat (seq request)))]
+              (apply match-route route path (apply concat (seq req)))]
           (when handler
             (request
              (handler-fn handler)
-             (-> request
+             (-> req
                  (update-in [:params] merge route-params)
                  (update-in [:route-params] merge route-params))
-             (apply dissoc match-context :handler (keys request))
+             (apply dissoc match-context :handler (keys req))
              )))))
    ([route] (make-handler route identity)))
 


### PR DESCRIPTION
Hi,

make-handler is broken for me in 1.17.0.

This pull request fixes that by preventing the shadowing of the request fn by request map.

Cheers

btw, it might be worth setting up the project on circleci or similar? This was caught by your tests. Thanks for bidi, I'm really loving it.