### PR TITLE
(#57) Support regexes in compile-route

### DIFF
--- a/src/bidi/bidi.cljx
+++ b/src/bidi/bidi.cljx
@@ -398,6 +398,7 @@ actually a valid UUID (this is handled by the route matching logic)."
   #+cljs cljs.core.PersistentVector
   (compile-pattern [v] (mapv compile-segment v))
   (compile-matched [v] (mapv compile-route v))
+  (compile-segment [v] v)
 
   #+clj clojure.lang.PersistentList
   #+cljs cljs.core.List

--- a/test/bidi/bidi_test.cljx
+++ b/test/bidi/bidi_test.cljx
@@ -5,6 +5,7 @@
   (:require #+clj [clojure.test :refer :all]
             #+cljs [cemerick.cljs.test :as t]
             [bidi.bidi :as bidi :refer [match-route
+                                        compile-route
                                         path-for
                                         ->Alternates]]))
 
@@ -199,3 +200,21 @@
     (is (= (match-route routes "/index") {:handler :index}))
     (is (= (path-for routes :index) "/index.html")) ; first is the canonical one
     ))
+
+(deftest compile-routes-test
+  (testing "basic route"
+    (let [routes [["/foo/" :bar] :foo]
+          compiled (compile-route routes)
+          path "/foo/hello"
+          match {:handler      :foo
+                 :route-params {:bar "hello"}}]
+      (is (= (match-route routes path) match))
+      (is (= (match-route compiled path) match))))
+  (testing "route with regex"
+    (let [routes [["/foo/" [#".*" :extra]] :foo]
+          compiled (compile-route routes)
+          path "/foo/hello/bar/baz"
+          match {:handler      :foo
+                 :route-params {:extra "hello/bar/baz"}}]
+      (is (= (match-route routes path) match))
+      (is (= (match-route compiled path) match)))))


### PR DESCRIPTION
This patch addresses issue #57 and allows routes that contain regular expressions (as per the README) to be used within 'compile-route'.