### PR TITLE
Update current version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ HTTP servers (including Jetty, [http-kit](http://http-kit.org/) and
 Add the following dependency to your `project.clj` file
 
 ```clojure
-[bidi "1.18.11"]
+[bidi "1.19.0"]
 ```
 
 ## Take 5 minutes to learn bidi (using the REPL)


### PR DESCRIPTION
This bit me while trying out yada; route-seq isn't a thing in the version claimed in the README.

(I'm fairly new to Clojure; is there a reason not to use Clojars' badges?)