### PR TITLE
add swagger-path-for function

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ HTTP servers (including Jetty, [http-kit](http://http-kit.org/) and
 Add the following dependency to your `project.clj` file
 
 ```clojure
-[bidi "1.18.11"]
+[bidi "1.19.0"]
 ```
 
 ## Take 5 minutes to learn bidi (using the REPL)

--- a/src/bidi/bidi.cljx
+++ b/src/bidi/bidi.cljx
@@ -223,7 +223,6 @@ actually a valid UUID (this is handled by the route matching logic)."
     (when this (assoc env :remainder "")))
 
   #+clj clojure.lang.APersistentVector
-  ;; TODO: Perhaps use IVector
   #+cljs cljs.core.PersistentVector
   (match-pattern [this env]
     (when-let [groups (as-> this %

--- a/src/bidi/ring.clj
+++ b/src/bidi/ring.clj
@@ -60,6 +60,8 @@
         true (dissoc :remainder))))
   (unresolve-handler [this m]
     (when (= this (:handler m)) ""))
+  (swagger-unresolve-handler [this m]
+    (when (= this (:handler m)) ""))
   Ring
   (request [f req m]
     (if-let [location (if-not (string? target) (:location m) target)]
@@ -90,6 +92,8 @@
                          (wrap-not-modified))
                      (fn [req] {:status 404}))))))
   (unresolve-handler [this m]
+    (when (= this (:handler m)) ""))
+  (swagger-unresolve-handler [this m]
     (when (= this (:handler m)) "")))
 
 (defn resources [options]
@@ -115,6 +119,8 @@
                          (wrap-content-type options)
                          (wrap-not-modified)))))))
   (unresolve-handler [this m]
+    (when (= this (:handler m)) ""))
+  (swagger-unresolve-handler [this m]
     (when (= this (:handler m)) "")))
 
 (defn resources-maybe [options]
@@ -133,6 +139,8 @@
                      (wrap-content-type options)
                      (wrap-not-modified))))
   (unresolve-handler [this m]
+    (when (= this (:handler m)) ""))
+  (swagger-unresolve-handler [this m]
     (when (= this (:handler m)) "")))
 
 (defn files [options]
@@ -158,6 +166,8 @@
               (wrap-not-modified)))
             (dissoc :remainder)))))
   (unresolve-handler [this m]
+    (when (= this (:handler m)) ""))
+  (swagger-unresolve-handler [this m]
     (when (= this (:handler m)) "")))
 
 (defn archive [options]
@@ -170,7 +180,8 @@
   (resolve-handler [this m]
     (let [r (resolve-handler matched m)]
       (if (:handler r) (update-in r [:handler] middleware) r)))
-  (unresolve-handler [this m] (unresolve-handler matched m))) ; pure delegation
+  (unresolve-handler [this m] (unresolve-handler matched m))
+  (swagger-unresolve-handler [this m] (swagger-unresolve-handler matched m))) ; pure delegation
 
 (defn wrap-middleware [matched middleware]
   (->WrapMiddleware matched middleware))


### PR DESCRIPTION
to generate keys for the 'paths' part of the swagger description

following up our discussion on the juxt mailing list I added swagger info to my project using vanilla ring swagger. however it kept bugging me that in that nice `routes` bidi data-structure I have at least part of the information I need to generate the swagger description. I came up with something like this:

```clojure
(defn swaggerise [info handler-keys routes swagger-descriptions]
  {:info info
   :paths (->> handler-keys
               (map (juxt identity #(bidi/path-for routes % :id ":id" :ts ":ts")))
               (remove (comp nil? second))
               (mapcat #(vector (second %) (-> % first swagger-descriptions)))
               (apply hash-map)
               (#(zipmap (keys %) (->> % vals (replace {nil {:get nil}})))))})
```

however, the `bidi/path-for` call is kinda awkward here as I have to hardcode all the params that may occur in my routes data-structure.

hence the helper function which generates the appropriate path for swagger. hope it makes sense...