### PR TITLE
:exclude uuid

### DIFF
--- a/src/bidi/bidi.cljx
+++ b/src/bidi/bidi.cljx
@@ -2,7 +2,8 @@
 
 (ns bidi.bidi
   (:require [clojure.walk :as walk :refer [postwalk]]
-            [cemerick.url :as url :refer [url-encode url-decode]]))
+            [cemerick.url :as url :refer [url-encode url-decode]])
+  (:refer-clojure :exclude [uuid]))
 
 (defn uuid
   "Function for creating a UUID of the appropriate type for the platform.


### PR DESCRIPTION
Should prevent this message when compiling:
```
WARNING: uuid already refers to: cljs.core/uuid being replaced by: bidi.bidi/uuid ...
```