### PR TITLE
First bash: Adding a CLJS 'router' that sets and reacts to changes in the hash fragment

### DIFF
--- a/src/bidi/router.cljs
+++ b/src/bidi/router.cljs
@@ -1,0 +1,75 @@
+(ns bidi.router
+  (:require [bidi.bidi :as bidi]
+            [goog.History :as h]
+            [goog.events :as e])
+  (:import [goog History]))
+
+(defprotocol Router
+  (set-location! [_ location])
+  (replace-location! [_ location]))
+
+(defn start-router!
+  "Starts up a Bidi router based on Google Closure's 'History'
+
+  Types:
+
+    Location :- {:handler ...
+                 :route-params {...}}
+
+  Parameters:
+
+    routes :- a Bidi route structure
+    on-navigate :- 0-arg function, accepting a Location
+    default-location :- Location to default to if the current token doesn't match a route
+
+  Returns :- Router
+
+  Example usage:
+
+    (require '[bidi.router :as br])
+
+    (let [!location (atom nil)
+          router (br/start-router! [\"\" {\"/\" ::home-page
+                                          \"/page2\" ::page2}]
+                                   {:on-navigate (fn [location]
+                                                   (reset! !location location))
+                                    :default-location {:handler ::home-page}})]
+
+      ...
+
+      (br/set-location! router {:handler ::page2}))"
+
+  [routes {:keys [on-navigate default-location]
+           :or {on-navigate (constantly nil)}}]
+
+  (let [history (History.)]
+    (.setEnabled history true)
+
+    (letfn [(token->location [token]
+              (or (bidi/match-route routes token)
+                  default-location))
+
+            (location->token [{:keys [handler route-params]}]
+              (bidi/unmatch-pair routes {:handler handler
+                                         :params route-params}))]
+
+      (e/listen history h/EventType.NAVIGATE
+                (fn [e]
+                  (on-navigate (token->location (.-token e)))))
+
+      (let [initial-token (let [token (.getToken history)]
+                            (if-not (s/blank? token)
+                              token
+                              (or (location->token default-location) "/")))
+
+            initial-location (token->location initial-token)]
+
+        (.replaceToken history initial-token)
+        (on-navigate initial-location))
+
+      (reify Router
+        (set-location! [_ location]
+          (.setToken history (location->token location)))
+
+        (replace-location! [_ location]
+          (.replaceToken history (location->token location)))))))


### PR DESCRIPTION
Hi Malcolm,

Have had a first bash at writing a CLJS router for Bidi - taking in a Bidi route structure and using Closure's 'History' to set and react to changes in the hash-fragment part of the URL.

Example usage:

```clojure
(require '[bidi.router :as br])

(let [!location (atom nil)
      router (br/start-router! ["" {"/" ::home-page
                                    "/page2" ::page2}]
                               {:on-navigate (fn [location]
                                               (reset! !location location))
                                :default-location {:handler ::home-page}})]

  ...

  (br/set-location! router {:handler ::page2}))
```

What do you think? More than happy to release this as a separate library if you don't think it belongs in Bidi core :)

We're getting an awful lot of use out of Bidi, btw - really appreciating having routes-as-data :)

Cheers,

James