### PR TITLE
Added support for using vars as handlers

### DIFF
--- a/src/bidi/ring.clj
+++ b/src/bidi/ring.clj
@@ -19,7 +19,11 @@
 (extend-protocol Ring
   clojure.lang.Fn
   (request [f req _]
-    (f req)))
+    (f req))
+
+  clojure.lang.Var
+  (request [v req _]
+    ((deref v) req)))
 
 (defn make-handler
   "Create a Ring handler from the route definition data

--- a/test/bidi/ring_test.clj
+++ b/test/bidi/ring_test.clj
@@ -65,7 +65,16 @@
     (let [handler-lookup {:my-handler (fn [req] {:status 200 :body "Index"})}
           handler (make-handler ["/" :my-handler] (fn [handler-id] (handler-id handler-lookup)))]
       (is handler)
-      (is (= (handler (mock-request :get "/")) {:status 200 :body "Index"})))))
+      (is (= (handler (mock-request :get "/")) {:status 200 :body "Index"}))))
+
+  (testing "using handler vars"
+    (defn test-handler [req] {:status 200 :body "Index"})
+    (let [handler
+          (make-handler ["/"
+                         [["" (-> #'test-handler (tag :index))]]])]
+      (is handler)
+      (is (= (handler (mock-request :get "/"))
+             {:status 200 :body "Index"})))))
 
 (deftest route-params-hygiene-test
   (let [handler


### PR DESCRIPTION
When using vars for you handlers instead of fns / lambdas you can reload that handler function (and reload-the page) instead of doing a full (reset) to observe your changes.