### PR TITLE
Upgrade to Schema 1.0.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
 
-  :dependencies [[prismatic/schema "0.4.3"]
+  :dependencies [[prismatic/schema "1.0.1"]
                  [com.cemerick/url "0.1.1"]
                  [ring/ring-core "1.3.2" :exclusions [org.clojure/tools.reader]]]
 

--- a/src/bidi/schema.cljx
+++ b/src/bidi/schema.cljx
@@ -8,32 +8,31 @@
 (def Path s/Str)
 
 (def PatternSegment
-  (s/either s/Str
-            s/Regex
-            s/Keyword
-            (s/pair (s/either s/Str s/Regex) "qual" s/Keyword "id")))
+  (s/cond-pre s/Str
+              s/Regex
+              s/Keyword
+              (s/pair (s/cond-pre s/Str s/Regex) "qual" s/Keyword "id")))
 
 (def MethodGuard
   (s/enum :get :post :put :delete :head :options))
 
 (def GeneralGuard
-  {s/Keyword (s/either s/Str s/Keyword (s/=> s/Any s/Any))})
+  {s/Keyword (s/cond-pre s/Str s/Keyword (s/=> s/Any s/Any))})
 
 (def Pattern
-  (s/either Path
-            [PatternSegment]
-            MethodGuard
-            GeneralGuard
-            s/Bool))
+  (s/cond-pre Path
+              [PatternSegment]
+              MethodGuard
+              GeneralGuard
+              s/Bool))
 
 (declare ^:export RoutePair)
 
 (def Matched
-  (s/either
-   (s/=> s/Any s/Any)
-   s/Symbol
-   s/Keyword
-   [(s/recursive #'RoutePair)]
-   {Pattern (s/recursive #'Matched)}))
+  (s/cond-pre (s/=> s/Any s/Any)
+              s/Symbol
+              s/Keyword
+              [(s/recursive #'RoutePair)]
+              {Pattern (s/recursive #'Matched)}))
 
 (def ^:export RoutePair (s/pair Pattern "" Matched ""))


### PR DESCRIPTION
Change uses of `either` (deprecated) to use `cond-pre`, which is Schema
1.0.1's replacement. `either` no longer works, and throws a
`StackOverflow` exception.