### PR TITLE
Switch from clojurescript.test to cljs.test

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                  [ring/ring-core "1.4.0"]]
 
   :plugins [[lein-cljsbuild "1.0.3"]
-            [com.cemerick/clojurescript.test "0.3.1"]]
+            [lein-doo "0.1.4"]]
 
   :prep-tasks ["javac" "compile"]
 
@@ -23,17 +23,15 @@
                                   [criterium "0.4.3"]]}}
 
   :aliases {"deploy" ["do" "clean," "deploy" "clojars"]
-            "test" ["do" "clean," "test," "with-profile" "dev" "cljsbuild" "test"]}
+            "test" ["do" "clean," "test," "doo" "phantom" "test" "once"]}
 
   :jar-exclusions [#"\.swp|\.swo|\.DS_Store"]
 
   :lein-release {:deploy-via :shell
                  :shell ["lein" "deploy"]}
 
-  :cljsbuild {:test-commands {"unit" ["phantomjs" :runner
-                                      "window.literal_js_was_evaluated=true"
-                                      "target/unit-test.js"]}
-              :builds
+  :cljsbuild {:builds
               {:test {:source-paths ["src" "test"]
                       :compiler {:output-to "target/unit-test.js"
+                                 :main 'bidi.runner
                                  :optimizations :whitespace}}}})

--- a/test/bidi/bidi_test.cljc
+++ b/test/bidi/bidi_test.cljc
@@ -1,11 +1,10 @@
 ;; Copyright © 2014, JUXT LTD.
 
 (ns bidi.bidi-test
-  #?(:cljs (:require-macros [cemerick.cljs.test :refer [is testing deftest]]))
-  (:require #?(:clj [clojure.test :refer :all]
-               :cljs [cemerick.cljs.test :as t])
-            [bidi.bidi :as bidi
-             :refer [match-route path-for ->Alternates route-seq]]))
+  (:require
+    #?(:clj  [clojure.test :refer :all]
+       :cljs [cljs.test :refer-macros [deftest is testing]])
+    [bidi.bidi :as bidi :refer [match-route path-for ->Alternates route-seq]]))
 
 (deftest matching-routes-test
   (testing "misc-routes"

--- a/test/bidi/runner.cljs
+++ b/test/bidi/runner.cljs
@@ -1,0 +1,9 @@
+;; Copyright © 2014, JUXT LTD.
+
+(ns bidi.runner
+  (:require [doo.runner :refer-macros [doo-tests]]
+            [bidi.bidi-test]
+            [bidi.schema-test]))
+
+(doo-tests 'bidi.bidi-test
+           'bidi.schema-test)

--- a/test/bidi/schema_test.cljc
+++ b/test/bidi/schema_test.cljc
@@ -1,9 +1,9 @@
 ;; Copyright © 2014-2015, JUXT LTD.
 
 (ns bidi.schema-test
-  #?(:cljs (:require-macros [cemerick.cljs.test :refer [is testing deftest]]))
   (:require
-    #?(:clj [clojure.test :refer :all] :cljs [cemerick.cljs.test :as t])
+    #?(:clj  [clojure.test :refer :all]
+       :cljs [cljs.test :refer-macros [deftest is testing]])
     [schema.core :as s]
     [bidi.schema :as bs]))
 


### PR DESCRIPTION
`clojurescript.test` has been deprecated in favour of `cljs.test`, the
testing library that ships with ClojureScript. In place of the test
runner provided by `clojurescript.test`, we use `doo`.