### PR TITLE
Integer support for `path-for`

### DIFF
--- a/src/bidi/bidi.cljc
+++ b/src/bidi/bidi.cljc
@@ -35,6 +35,9 @@ actually a valid UUID (this is handled by the route matching logic)."
      :cljs number)
   (encode-parameter [s] s)
 
+  #?(:clj Integer)
+  #?(:clj (encode-parameter [s] s))
+
   #?(:clj java.util.UUID
      :cljs cljs.core.UUID)
   (encode-parameter [s] (str s))

--- a/test/bidi/bidi_test.cljc
+++ b/test/bidi/bidi_test.cljc
@@ -165,6 +165,7 @@
     (is (= (:route-params (match-route routes "/foo/345")) {:id 345}))
     (is (= (path-for routes :y :id -1000) "/foo/-1000"))
     (is (= (path-for routes :y :id 1234567) "/foo/1234567"))
+    (is (= (path-for routes :y :id (int 1234567)) "/foo/1234567"))
 
     (is (= (:handler (match-route routes "/foo/0/bar")) :z))
     (is (= (path-for routes :z :id 12) "/foo/12/bar"))

--- a/test/bidi/bidi_test.cljc
+++ b/test/bidi/bidi_test.cljc
@@ -165,13 +165,19 @@
     (is (= (:route-params (match-route routes "/foo/345")) {:id 345}))
     (is (= (path-for routes :y :id -1000) "/foo/-1000"))
     (is (= (path-for routes :y :id 1234567) "/foo/1234567"))
-    (is (= (path-for routes :y :id (int 1234567)) "/foo/1234567"))
 
     (is (= (:handler (match-route routes "/foo/0/bar")) :z))
     (is (= (path-for routes :z :id 12) "/foo/12/bar"))
 
     (testing "bigger than longs"
       (is (nil? (match-route routes "/foo/1012301231111111111111111111"))))))
+
+(deftest integer-test
+  (let [routes ["/" [["foo/" :x]
+                     [["foo/" [long :id]] :y]
+                     [["foo/" [long :id] "/bar"] :z]]]]
+    (is (= (path-for routes :y :id (int 1234567)) "/foo/1234567"))
+    (is (= (path-for routes :z :id (int 12)) "/foo/12/bar"))))
 
 (deftest uuid-test
   (let [routes ["/" [["foo/" :x]


### PR DESCRIPTION
This adds the `Integer` implementation to the `ParameterEncoding` protocol.

`path-for` did not support `Integer` types, which is confusing because it's often hard to tell if you're passing in a `Long` or `Integer` (especially if the numeric came from a library that you do not control, e.g. an integer DB column from [yesql](https://github.com/krisajenkins/yesql)).

Here is a failing case:

```clojure
(def test-route ["" {["/" :id] :id-handler}])

(bidi/path-for test-route :id-handler :id 123)
; "/123"

(bidi/path-for test-route :id-handler :id (int 123))
;; java.lang.IllegalArgumentException: No implementation of method: :encode-parameter of protocol: #'bidi.bidi/ParameterEncoding found for class: java.lang.Integer
```