### PR TITLE
Add version badge 

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,7 @@ HTTP servers (including Jetty, [http-kit](http://http-kit.org/) and
 
 Add the following dependency to your `project.clj` file
 
-```clojure
-[bidi "1.21.1"]
-```
+[![Clojars Project](http://clojars.org/bidi/latest-version.svg)](http://clojars.org/bidi)
 
 ## Take 5 minutes to learn bidi (using the REPL)
 


### PR DESCRIPTION
The version number was outdated, using Clojars prevents any cat & mouse with remembering where to update version numbers.