### PR TITLE
Add support for PATCH method

### DIFF
--- a/src/bidi/schema.cljc
+++ b/src/bidi/schema.cljc
@@ -14,7 +14,7 @@
               (s/pair (s/cond-pre s/Str s/Regex) "qual" s/Keyword "id")))
 
 (def MethodGuard
-  (s/enum :get :post :put :delete :head :options))
+  (s/enum :get :post :put :patch :delete :head :options))
 
 (def GeneralGuard
   {s/Keyword (s/cond-pre s/Str s/Keyword (s/=> s/Any s/Any))})

--- a/src/bidi/schema.cljc
+++ b/src/bidi/schema.cljc
@@ -29,10 +29,10 @@
 (declare ^:export RoutePair)
 
 (def Matched
-  (s/cond-pre (s/=> s/Any s/Any)
-              s/Symbol
+  (s/cond-pre s/Symbol
               s/Keyword
               [(s/recursive #'RoutePair)]
-              {Pattern (s/recursive #'Matched)}))
+              {Pattern (s/recursive #'Matched)}
+              (s/=> s/Any s/Any)))
 
 (def ^:export RoutePair (s/pair Pattern "" Matched ""))

--- a/test/bidi/schema_test.cljc
+++ b/test/bidi/schema_test.cljc
@@ -30,7 +30,9 @@
 
   (testing "method guards"
     (is (nil? (s/check bs/RoutePair ["/" {:get :get-handler
-                                          :post :post-handler}]))))
+                                          :post :post-handler}])))
+
+    (is (not (nil? (s/check bs/RoutePair ["/" {:not-a-recognised-method :handler}])))))
 
   (testing "general guards"
     (is (nil?

--- a/test/bidi/schema_test.cljc
+++ b/test/bidi/schema_test.cljc
@@ -30,7 +30,8 @@
 
   (testing "method guards"
     (is (nil? (s/check bs/RoutePair ["/" {:get :get-handler
-                                          :post :post-handler}])))
+                                          :post :post-handler
+                                          :patch :patch-handler}])))
 
     (is (not (nil? (s/check bs/RoutePair ["/" {:not-a-recognised-method :handler}])))))
 


### PR DESCRIPTION
Hi ---

This pull request just updates the schema to include ':patch' in the MethodGuard enum.  While doing that, noticed that the 'Matched' schema tended to short-circuit at (s/=> s/Any s/Any) as maps are treated as callables, and was thus too permissive --- fixed by reordering the terms in the s/pre-cond expression.  Added a test case for this situation.

Haven't got phantomjs running on my dev box at the moment (problem during installation I haven't figured out), so haven't run the clojurescript tests, but the clojure ones are passing.

best,
Duncan