### PR TITLE
Ignore query parameters in a url when matching.

### DIFF
--- a/src/bidi/bidi.cljc
+++ b/src/bidi/bidi.cljc
@@ -4,7 +4,8 @@
   (:require [clojure.walk :as walk :refer [postwalk]]
             [cemerick.url :as url :refer [url-encode url-decode]]
             [schema.core :as s])
-  (:refer-clojure :exclude [uuid]))
+  (:refer-clojure :exclude [uuid])
+  #?(:cljs (:import goog.Uri)))
 
 (defn uuid
   "Function for creating a UUID of the appropriate type for the platform.
@@ -174,13 +175,19 @@ actually a valid UUID (this is handled by the route matching logic)."
   (resolve-handler [_ m])
   (unresolve-handler [_ m]))
 
+(defn just-path
+  [path]
+  #?(:clj (.getRawPath (java.net.URI. path)) ;; Raw path means encoded chars are kept.
+     :cljs (.getPath (goog.Uri. path))))
+
 (defn match-pair
   "A pair contains a pattern to match (either fully or partially) and an
   expression yielding a handler. The second parameter is a map
   containing state, including the remaining path."
-  [[pattern matched] env]
-  (when-let [match-result (match-pattern pattern env)]
-    (resolve-handler matched (merge env match-result))))
+  [[pattern matched] orig-env]
+  (let [env (update orig-env :remainder just-path)]
+    (when-let [match-result (match-pattern pattern env)]
+      (resolve-handler matched (merge env match-result)))))
 
 (defn match-beginning
   "Match the beginning of the :remainder value in m. If matched, update
@@ -394,8 +401,8 @@ actually a valid UUID (this is handled by the route matching logic)."
 
   #?(:clj Object
      :cljs default)
-  (gather [this context] [(map->Route (assoc context :handler this))])
-  )
+  (gather [this context] [(map->Route (assoc context :handler this))]))
+  
 
 ;; --------------------------------------------------------------------------------
 ;; Protocols

--- a/test/bidi/bidi_test.cljc
+++ b/test/bidi/bidi_test.cljc
@@ -46,6 +46,12 @@
                         "/blog/articles/123/index.html")
            {:handler 'foo :route-params {:id "123"}}))
 
+    (is (= (match-route ["/blog" [["/foo" 'foo]
+                                  ["/bar" [["/abc" :bar]]]]]
+                        "/blog/bar/abc?q=2&b=str")
+           {:handler :bar}))
+
+
     (testing "regex"
       (is (= (match-route ["/blog" [[["/articles/" [#"[0-9]+" :id] "/index.html"] 'foo]
                                     ["/text" 'bar]]]
@@ -62,10 +68,10 @@
              {:handler 'foo :route-params {:id "123" :a "abc"}}))
 
       #?(:clj
-        (is (= (match-route [#"/bl[a-z]{2}+" [[["/articles/" [#"[0-9]+" :id] [#"[a-z]+" :a] "/index.html"] 'foo]
-                                                  ["/text" 'bar]]]
-                            "/blog/articles/123abc/index.html")
-              {:handler 'foo :route-params {:id "123" :a "abc"}})))
+         (is (= (match-route [#"/bl[a-z]{2}+" [[["/articles/" [#"[0-9]+" :id] [#"[a-z]+" :a] "/index.html"] 'foo]
+                                               ["/text" 'bar]]]
+                             "/blog/articles/123abc/index.html")
+               {:handler 'foo :route-params {:id "123" :a "abc"}})))
 
       (is (= (match-route [["/blog/articles/123/" :path] 'foo]
                           "/blog/articles/123/index.html")
@@ -206,8 +212,8 @@
   (let [routes [(->Alternates ["/index.html" "/index"]) :index]]
     (is (= (match-route routes "/index.html") {:handler :index}))
     (is (= (match-route routes "/index") {:handler :index}))
-    (is (= (path-for routes :index) "/index.html")) ; first is the canonical one
-    ))
+    (is (= (path-for routes :index) "/index.html")))) ; first is the canonical one
+    
 
 (deftest route-seq-test
   (let [myroutes


### PR DESCRIPTION
Uses core-ish the URI libraries to match against just the path from a
given URI (and excludes query params!)

Also adds a test for this case.

Sorry for the new PR as you'd merged the old one, things seem to be getting confused!