### PR TITLE
Correct usage of alts in README, add corresponding test.

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,7 +549,7 @@ which each match the handler. The first in the list is considered the
 canonical pattern for the purposes of URI formation.
 
 ```clojure
-[(alts ["/index.html" "/index"]) :index]
+[(alts "/index.html" "/index") :index]
 ```
 
 Any pattern can be used in the list. This allows quite sophisticated
@@ -557,13 +557,13 @@ matching. For example, if you want to match on requests that are either
 HEAD or GET but not anything else.
 
 ```clojure
-[(alts [:head :get]) :index]
+[(alts :head :get) :index]
 ```
 
 Or match if the server name is `juxt.pro` or `localhost`.
 
 ```clojure
-[(alts [{:server-name "juxt.pro"}{:server-name "localhost"}])
+[(alts {:server-name "juxt.pro"}{:server-name "localhost"})
  {"/index.html" :index}]
 ```
 

--- a/test/bidi/bidi_test.cljc
+++ b/test/bidi/bidi_test.cljc
@@ -4,7 +4,7 @@
   (:require
     #?(:clj  [clojure.test :refer :all]
        :cljs [cljs.test :refer-macros [deftest is testing]])
-    [bidi.bidi :as bidi :refer [match-route path-for ->Alternates route-seq]]))
+    [bidi.bidi :as bidi :refer [match-route path-for ->Alternates route-seq alts]]))
 
 (deftest matching-routes-test
   (testing "misc-routes"
@@ -62,10 +62,10 @@
              {:handler 'foo :route-params {:id "123" :a "abc"}}))
 
       #?(:clj
-        (is (= (match-route [#"/bl[a-z]{2}+" [[["/articles/" [#"[0-9]+" :id] [#"[a-z]+" :a] "/index.html"] 'foo]
-                                                  ["/text" 'bar]]]
-                            "/blog/articles/123abc/index.html")
-              {:handler 'foo :route-params {:id "123" :a "abc"}})))
+         (is (= (match-route [#"/bl[a-z]{2}+" [[["/articles/" [#"[0-9]+" :id] [#"[a-z]+" :a] "/index.html"] 'foo]
+                                               ["/text" 'bar]]]
+                             "/blog/articles/123abc/index.html")
+               {:handler 'foo :route-params {:id "123" :a "abc"}})))
 
       (is (= (match-route [["/blog/articles/123/" :path] 'foo]
                           "/blog/articles/123/index.html")
@@ -203,8 +203,10 @@
   (let [routes [(->Alternates ["/index.html" "/index"]) :index]]
     (is (= (match-route routes "/index.html") {:handler :index}))
     (is (= (match-route routes "/index") {:handler :index}))
-    (is (= (path-for routes :index) "/index.html")) ; first is the canonical one
-    ))
+    (is (= (path-for routes :index) "/index.html"))) ; first is the canonical one
+  (let [routes [(alts "/index.html" "/index") :index]]
+    (is (= (match-route routes "/index.html") {:handler :index}))
+    (is (= (match-route routes "/index") {:handler :index}))))
 
 (deftest route-seq-test
   (let [myroutes


### PR DESCRIPTION
Whilst playing with #106 I noticed that the README has incorrect usage of alts, this corrects it and adds a unit test for the use-case also.