### PR TITLE
Enable CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+test:
+  override:
+    - 'lein test'


### PR DESCRIPTION
TravisCI unfortunately runs an old version of Leiningen (https://github.com/travis-ci/travis-ci/issues/5025) which means that .cljc tests are not run on the jvm, see this build: https://travis-ci.org/juxt/bidi/builds/98033023

> Ran 6 tests containing 34 assertions.

I've just tried circleci on my fork, and you can see in the test section that all is functional once more: https://circleci.com/gh/SevereOverfl0w/bidi/5

All tests are run in both areas. Success!

---

I have not removed `travis.yml` in this commit (but can). There is no reason not to have both enabled and choose a favourite at a later time. Also, the circle.yml file is not necessary, when enabling circleci for this repo, you can go into the project settings and just enter `lein test` as the test command, it defaults to `lein trampoline test` which fails as we use test to chain together multiple commands. I like the `circleci.yml` as it's more explicit than a project setting though.