### PR TITLE
Name the RoutePair schemas

### DIFF
--- a/src/bidi/schema.cljc
+++ b/src/bidi/schema.cljc
@@ -35,4 +35,4 @@
               {Pattern (s/recursive #'Matched)}
               (s/=> s/Any s/Any)))
 
-(def ^:export RoutePair (s/pair Pattern "" Matched ""))
+(def ^:export RoutePair (s/pair Pattern "Pattern" Matched "Matched"))


### PR DESCRIPTION
This improves slightly the error messages given when schema-checking fails.
Right now we have : ` (schema/check bidi.schema/RoutePair []) ;; [(not (present? "")) (not (present? ""))] `