### PR TITLE
Allow path chunks to start with a colon

### DIFF
--- a/src/bidi/bidi.cljc
+++ b/src/bidi/bidi.cljc
@@ -186,8 +186,11 @@ actually a valid UUID (this is handled by the route matching logic)."
 
 (defn just-path
   [path]
-  #?(:clj (.getRawPath (java.net.URI. path)) ;; Raw path means encoded chars are kept.
-     :cljs (.getPath (goog.Uri. path))))
+  (let [uri-string (str "file:///" path)]
+    ;; Raw path means encoded chars are kept.
+    (subs #?(:clj (.getRawPath (java.net.URI. uri-string))
+             :cljs (.getPath (goog.Uri. uri-string)))
+          1)))
 
 (defn match-pair
   "A pair contains a pattern to match (either fully or partially) and an

--- a/test/bidi/bidi_test.cljc
+++ b/test/bidi/bidi_test.cljc
@@ -239,3 +239,11 @@
   (let [myroutes [true :foo]]
     (is (= {:handler :foo} (match-route myroutes "/")))
     (is (= "" (path-for myroutes :foo)))))
+
+(deftest colon-test
+  (let [myroutes ["/" {":a" :a
+                       "b" :b}]]
+    (is (= {:handler :a} (match-route myroutes "/:a")))
+    (is (= {:handler :b} (match-route myroutes "/b")))
+    (is (nil? (match-route myroutes "/a")))
+    (is (nil? (match-route myroutes "/:b")))))


### PR DESCRIPTION
Paths with chunks starting with colons — /like/::this/:one — are valid
but they were not parsed correctly by bidi. The reason was an exception
thrown by the java.net.URI constructor invoked in bidi/just-path.
java.net.URI assumed that a string like ":a" was missing a required URI
schema and threw.  Similar issues occurred in the ClojureScript edition.

This patch solves the problem by prefixing the path with an explicit
schema file:/// before invoking the constructor. Afterwards it drops
the slash which got prepended.

Interestingly enough, replacing bidi/just-path with the following
implementation solves the problem too and according to the test suite
it doesn't appear to be introducing any regressions. This being said,
my gut feeling tells me it might bite us in the future.

    (defn just-path
      [path]
      (apply str (take-while #(not= \? %) path))