### PR TITLE
Stricter schema and corner cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,6 @@ pom.xml.asc
 /.nrepl-port
 /todo.org
 .repl/
+/.idea/
+*.iml
 out/

--- a/src/bidi/schema.cljc
+++ b/src/bidi/schema.cljc
@@ -8,11 +8,14 @@
 
 (def Path s/Str)
 
+(defn valid-qualifier-function? [qual]
+  (contains? #{keyword long bidi/uuid} qual))
+
 (def PatternSegment
   (s/cond-pre s/Str
               s/Regex
               s/Keyword
-              (s/pair (s/cond-pre s/Str s/Regex) "qual" s/Keyword "id")))
+              (s/pair (s/conditional #(fn? %) (s/pred valid-qualifier-function?) :else s/Regex) "qual" s/Keyword "id")))
 
 (def MethodGuard
   (s/enum :get :post :put :patch :delete :head :options))
@@ -20,10 +23,23 @@
 (def GeneralGuard
   {s/Keyword (s/cond-pre s/Str s/Keyword (s/=> s/Any s/Any))})
 
+(s/defschema SegmentedPattern
+  (s/constrained [PatternSegment] not-empty 'not-empty))
+
+(declare Pattern)
+
+(s/defschema AlternatesSet
+  (s/constrained #{(s/recursive #'Pattern)} not-empty 'not-empty))
+
+(s/defschema DeprecatedAlternates
+  (s/record bidi.bidi.Alternates
+            {:alts [(s/recursive #'Pattern)]}))
+
 (def Pattern
-  (s/cond-pre (s/protocol bidi/Pattern)
+  (s/cond-pre AlternatesSet #_(s/protocol bidi/Pattern)
+              DeprecatedAlternates
               Path
-              [PatternSegment]
+              SegmentedPattern
               MethodGuard
               GeneralGuard
               s/Bool))

--- a/test/bidi/bidi_test.cljc
+++ b/test/bidi/bidi_test.cljc
@@ -262,6 +262,7 @@
   (testing "only leaves"
     (let [result (route-seq [#{"" "/"} [[:a "A"]
                                         [:b "B"]]])]
+      (is (= [["" :a] ["" :b] ["/" :a] ["/" :b]] (map :path result)))
       (is (= 4 (count result)))))
 
   (testing "tags"

--- a/test/bidi/schema_test.cljc
+++ b/test/bidi/schema_test.cljc
@@ -5,56 +5,139 @@
     #?(:clj  [clojure.test :refer :all]
        :cljs [cljs.test :refer-macros [deftest is testing]])
     [schema.core :as s]
+    #?(:clj [schema.macros :refer [if-cljs]])
     [bidi.bidi :as bidi]
-    [bidi.schema :as bs]))
+    [bidi.schema :as bs])
+  #?(:cljs (:require-macros [bidi.schema-test :refer [is-valid is-invalid testing-schema]])))
 
 ;; TODO
 
+(def ^{:dynamic true :tag s/Schema} *schema* nil)
+
+(defmacro is-valid
+  ([actual]
+    `(is-valid *schema* ~actual))
+  ([schema actual]
+   `(schema.macros/if-cljs
+      (cljs.test/is (= nil (s/check ~schema ~actual)))
+      (clojure.test/is (= nil (s/check ~schema ~actual))))))
+
+(defmacro is-invalid
+  ([expected actual]
+    `(is-invalid *schema* ~expected ~actual))
+  ([schema expected actual]
+   `(schema.macros/if-cljs
+      (cljs.test/is (= (str (quote ~expected)) (str (s/check ~schema ~actual))))
+      (clojure.test/is (= (str (quote ~expected)) (str (s/check ~schema ~actual)))))))
+
+(defmacro testing-schema [name schema & args]
+  `(schema.macros/if-cljs
+     (cljs.test/testing ~name
+       (binding [*schema* ~schema]
+         ~@args))
+     (clojure.test/testing ~name
+       (binding [*schema* ~schema]
+         ~@args))))
+
+
 (deftest schema-test
-  (testing "route-pairs"
+  (testing-schema "route pairs" bs/RoutePair
+    (testing "simple"
+      (is-valid ["/index/" :index])
 
-    (is (nil? (s/check bs/RoutePair ["/index/" :index])))
+      (is-valid ["/index/" [["a" :alpha]
+                            ["b" :beta]
+                            ["c" [["z" :zeta]]]]])
 
-    (is (nil? (s/check bs/RoutePair ["/index/" [["a" :alpha]
-                                                ["b" :beta]
-                                                ["c" [["z" :zeta]]]]])))
+      (is-valid ["/index/" {"a" :alpha
+                            "b" :beta
+                            "c" {"z" :zeta}}]))
 
-    (is (nil? (s/check bs/RoutePair ["/index/" {"a" :alpha
-                                                "b" :beta
-                                                "c" {"z" :zeta}}]))))
+    (testing "path segments"
+      (is-valid [["/" :i] :target])
+      (is-invalid [(named (not (not-empty [])) "Pattern") nil]
+                  [[] :test]))
 
-  (testing "path segments"
-    (is (nil? (s/check bs/RoutePair [["/" :i] :target]))))
+    (testing "qualified path segments"
+      (is-valid [["/" [#".*" :i]] :target])
+      (is-valid [["/" [keyword :i]] :target])
+      (is-valid [["/" [long :i]] :target])
+      (is-valid [["/" [bidi/uuid :i]] :target])
 
-  (testing "qualified path segments"
-    (is (nil? (s/check bs/RoutePair [["/" [#".*" :i]] :target]))))
+      (is-invalid
+        [(named [nil [(named (not (instance? #?(:clj  java.util.regex.Pattern
+                                                :cljs js/RegExp)
+                                             "muh"))
+                             "qual")
+                      nil]]
+                "Pattern")
+         nil]
+        [["/" ["muh" :i]] :target])
 
-  (testing "method guards"
-    (is (nil? (s/check bs/RoutePair ["/" {:get :get-handler
-                                          :post :post-handler
-                                          :patch :patch-handler}])))
+      (is-invalid
+        [(named [nil [(named (not #?(:clj  (bidi.schema/valid-qualifier-function? a-clojure.core$symbol)
+                                     :cljs (bidi$schema$valid-qualifier-function? a-function)))
+                             "qual")
+                      nil]]
+                "Pattern")
+         nil]
+        [["/" [symbol :i]] :target]))
 
-    ;; This test now fails since we allowed Patterns in schema
-    #_(is (not (nil? (s/check bs/RoutePair ["/" {:not-a-recognised-method :handler}])))))
+    (testing "method guards"
+      (is-valid ["/" {:get   :get-handler
+                      :post  :post-handler
+                      :patch :patch-handler}])
+      (is-valid [:get :test-handler])
+      (is-invalid [nil (named {(not (matches-some-precondition? #?(:clj a-clojure.lang.Keyword
+                                                                   :cljs a-object)))
+                               invalid-key}
+                              "Matched")]
+                  ["/" {:not-a-recognised-method :handler}]))
 
-  (testing "general guards"
-    (is (nil?
-         (s/check bs/RoutePair
-                  ["/" {"blog" {:get
-                                {"/index" (fn [req] {:status 200 :body "Index"})}}
-                        {:request-method :post :server-name "juxt.pro"}
-                        {"/zip" (fn [req] {:status 201 :body "Created"})}}]))))
+    (testing "general guards"
+      (is-valid
+        ["/" {"blog" {:get
+                      {"/index" (fn [req] {:status 200 :body "Index"})}}
+              {:request-method :post :server-name "juxt.pro"}
+                     {"/zip" (fn [req] {:status 201 :body "Created"})}}]))
 
-  (testing "common mistake"
-    (is (not (nil? (s/check bs/RoutePair ["/index/"
-                                          ["a" :alpha]
-                                          ["b" :beta]
-                                          ["c" [["z" :zeta]]]])))))
+    (testing "wrong patterns"
+      (is-invalid [(named (not (matches-some-precondition? :test)) "Pattern") nil]
+                  [:test :test-handler])
+      (is-invalid [(named (not (matches-some-precondition? 12)) "Pattern") nil]
+                  [12 :test])
+      (is-invalid
+        [(named {(not (#?(:clj  keyword?
+                          :cljs cljs$core$keyword?)
+                        14))
+                 invalid-key}
+                "Pattern")
+         nil]
+        [{14 12} :test])
+      (is-invalid
+        [(named {(not (#?(:clj  keyword?
+                          :cljs cljs$core$keyword?)
+                        "test"))
+                 invalid-key}
+                "Pattern")
+         nil]
+        [{"test" 12} :test]))
 
-  (testing "patterns"
-    (is (nil? (s/check bs/RoutePair
-                       ["/index/" [[(bidi/alts "foo" "bar") :foo-or-bar]]])))))
+    (testing "common mistake"
+      (is-invalid [nil (named [(not (sequential? "a"))
+                               (not (sequential? :alpha))] "Matched")
+                   (not (has-extra-elts? 2))]
+                  ["/index/"
+                   ["a" :alpha]
+                   ["b" :beta]
+                   ["c" [["z" :zeta]]]]))
 
+    (testing "sets"
+      (is-valid ["/index/" [[#{"foo" "bar"} :foo-or-bar]]])
+      (is-invalid [(named (not (not-empty #{})) "Pattern") nil]
+                  [#{} :test]))
 
-["/index/" [[(bidi/alts "foo" "bar") :foo-or-bar]]]
+    (testing "alts"
+      (is-valid [(bidi/alts) :empty])
+      (is-valid ["/index/" [[(bidi/alts "foo" "bar") :foo-or-bar]]]))))
 


### PR DESCRIPTION
When #106 was fixed the schema was made so general that the pattern part lost a lot of its value because any map, set or vector regardless of content is now a valid pattern according to the schema.

So I have made this pull request to narrow the schema down and to also start a conversation about which corner cases of bidi are valid or not so that we can have tests for them. My hope is that the schema can be narrowed down enough and tested enough that when the schema says that something is valid bidi syntax you are guaranteed that that is true.

Some of the corner cases I have come across:
- According to the BNF in the README this is invalid `[[] :test]` but the schema allowed it even before the change to fix #106. 
- This is valid according to the BNF but doesn't actually work: `[["/" ["test" :id]] :test]`
- Similarly this was invalid according to the schema and the BNF but works and is well tested and documented to work `[["/" [keyword :id]] :test]`
- According to the BNF this is a method guard `[:get :test]` but i don't know if it works
- Are any of these valid? `[nil :test]` `[#{} :test]` `[{} :test]`
