### PR TITLE
Fix `->Resources`

### DIFF
--- a/src/bidi/ring.clj
+++ b/src/bidi/ring.clj
@@ -88,8 +88,8 @@
           (-> (fn [req]
                 (if-let [res (resource-response (str (:prefix options) path))]
                   res
-                  {:status 404})
-                (wrap-content-type options)))))))
+                  {:status 404}))
+              (wrap-content-type options))))))
   (unresolve-handler [this m]
     (when (= this (:handler m)) "")))
 


### PR DESCRIPTION
`wrap-content` was being called inside the handler, rather than wraping it.