### PR TITLE
Avoid infinite loop when using URL in vhosts-model

### DIFF
--- a/src/bidi/vhosts.clj
+++ b/src/bidi/vhosts.clj
@@ -31,7 +31,7 @@
             (cond (instance? URI x)
                   {:scheme (keyword (.getScheme x))
                    :host (uri->host x)}
-                  (instance? URL x) (recur x)
+                  (instance? URL x) (recur (.toURI x))
                   (string? x) (recur (URI. x))
                   :otherwise x))}))
 


### PR DESCRIPTION
The new behavior is to turn the URL into a URI before recursing. This appears to be the intended behavior.