### PR TITLE
Added test for encoded uri

### DIFF
--- a/test/bidi/ring_test.clj
+++ b/test/bidi/ring_test.clj
@@ -21,6 +21,13 @@
       (is (= (handler (mock-request :get "/blog/index.html"))
              {:status 200 :body "Index"}))))
 
+  (testing "encoded uri"
+
+    (let [handler
+          (make-handler [["/" :encoded-id] (fn [req] {:status 200 :body "Content"})])]
+      (is (= (handler (mock-request :get "/id%2A1"))
+             {:status 200 :body "Content"}))))
+
   (testing "method constraints"
 
     (let [handler


### PR DESCRIPTION
Added a failing test for handling an encoded uri. I could not figure out how to fix it. Would love to see this fixed.