### PR TITLE
Unnest testing forms inside matching-routes-test

### DIFF
--- a/test/bidi/bidi_test.cljc
+++ b/test/bidi/bidi_test.cljc
@@ -49,37 +49,36 @@
     (is (= (match-route ["/blog" [["/foo" 'foo]
                                   ["/bar" [["/abc" :bar]]]]]
                         "/blog/bar/abc?q=2&b=str")
-           {:handler :bar}))
+           {:handler :bar})))
 
+  (testing "regex"
+    (is (= (match-route ["/blog" [[["/articles/" [#"[0-9]+" :id] "/index.html"] 'foo]
+                                  ["/text" 'bar]]]
+                        "/blog/articles/123/index.html")
+           {:handler 'foo :route-params {:id "123"}}))
+    (is (= (match-route ["/blog" [[["/articles/" [#"[0-9]+" :id] "/index.html"] 'foo]
+                                  ["/text" 'bar]]]
+                        "/blog/articles/123a/index.html")
+           nil))
 
-    (testing "regex"
-      (is (= (match-route ["/blog" [[["/articles/" [#"[0-9]+" :id] "/index.html"] 'foo]
-                                    ["/text" 'bar]]]
-                          "/blog/articles/123/index.html")
-             {:handler 'foo :route-params {:id "123"}}))
-      (is (= (match-route ["/blog" [[["/articles/" [#"[0-9]+" :id] "/index.html"] 'foo]
-                                    ["/text" 'bar]]]
-                          "/blog/articles/123a/index.html")
-             nil))
+    (is (= (match-route ["/blog" [[["/articles/" [#"[0-9]+" :id] [#"[a-z]+" :a] "/index.html"] 'foo]
+                                  ["/text" 'bar]]]
+                        "/blog/articles/123abc/index.html")
+           {:handler 'foo :route-params {:id "123" :a "abc"}}))
 
-      (is (= (match-route ["/blog" [[["/articles/" [#"[0-9]+" :id] [#"[a-z]+" :a] "/index.html"] 'foo]
-                                    ["/text" 'bar]]]
-                          "/blog/articles/123abc/index.html")
-             {:handler 'foo :route-params {:id "123" :a "abc"}}))
+    #?(:clj
+       (is (= (match-route [#"/bl[a-z]{2}+" [[["/articles/" [#"[0-9]+" :id] [#"[a-z]+" :a] "/index.html"] 'foo]
+                                             ["/text" 'bar]]]
+                           "/blog/articles/123abc/index.html")
+             {:handler 'foo :route-params {:id "123" :a "abc"}})))
 
-      #?(:clj
-         (is (= (match-route [#"/bl[a-z]{2}+" [[["/articles/" [#"[0-9]+" :id] [#"[a-z]+" :a] "/index.html"] 'foo]
-                                               ["/text" 'bar]]]
-                             "/blog/articles/123abc/index.html")
-               {:handler 'foo :route-params {:id "123" :a "abc"}})))
+    (is (= (match-route [["/blog/articles/123/" :path] 'foo]
+                        "/blog/articles/123/index.html")
+           {:handler 'foo :route-params {:path "index.html"}})))
 
-      (is (= (match-route [["/blog/articles/123/" :path] 'foo]
-                          "/blog/articles/123/index.html")
-             {:handler 'foo :route-params {:path "index.html"}})))
-
-    (testing "boolean patterns"
-      (is (= (match-route [true :index] "/any") {:handler :index}))
-      (is (= (match-route [false :index] "/any") nil)))))
+  (testing "boolean patterns"
+    (is (= (match-route [true :index] "/any") {:handler :index}))
+    (is (= (match-route [false :index] "/any") nil))))
 
 (deftest unmatching-routes-test
   (let [routes ["/"


### PR DESCRIPTION
The "regex" and "boolean patterns" testing forms were previously nested inside the "misc-routes" form, which I imagine was unintended?

Clojure runs the tests just the same either way, so yeah, I realize this is a nitpick of a commit, but it was throwing off the formatter :)

[Ignoring whitespace](https://github.com/juxt/bidi/compare/master...chbrown:fix-testing-nesting?w=1) helps depict the triviality of the change.
