### PR TITLE
Document make-handler handler-fn

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,33 @@ To chain this with middleware is simple.
       wrap-flash))
 ```
 
+To prevent mixing functions into your route definitions, you may pass an
+optional `handler-fn` to `make-handler`. This handler function will receive the
+match result as its only argument.
+
+```clojure
+(ns my.handler
+  (:require [bidi.ring :refer (make-handler)]
+            [ring.util.response :as res]))
+
+(defn index-handler
+  [request]
+  (res/response "Homepage"))
+
+(defn article-handler
+  [{:keys [route-params]}]
+  (res/response (str "You are viewing article: " (:id route-params))))
+
+(defn routes ["/" {"index.html" :index-handler
+                   ["articles/" :id "/article.html"] :article-handler}])
+
+(def handler-map {:index-handler index-handler :article-handler article-handler})
+
+(defn locate-handler [match-result] (get handler-map match-result))
+
+(def handler (make-handler routes locate-handler))
+```
+
 ### Regular Expressions
 
 We've already seen how keywords can be used to extract segments from a path. By default, keywords only capture numbers and simple identifiers. This is on purpose, in a defence against injection attacks. Often you'll want to specify exactly what you're trying to capture using a regular expression.


### PR DESCRIPTION
Way back in 2014, `make-handler` was modified to accept an optional `handler-fn` which could be used to look up handler functions by match results. However, this feature was never documented. This pull request adds a bit of documentation so users know that functionality exists.

For more information about the rationale behind this feature, see #27 .
