### PR TITLE
Allow more chars in URLs

### DIFF
--- a/src/bidi/bidi.cljc
+++ b/src/bidi/bidi.cljc
@@ -186,9 +186,8 @@ actually a valid UUID (this is handled by the route matching logic)."
 
 (defn just-path
   [path]
-  (let [uri-string (str "file:///" path)]
-    ;; Raw path means encoded chars are kept.
-    (subs #?(:clj (.getRawPath (java.net.URI. uri-string))
+  (let [uri-string (str "http://bidi.bidi/" path)]
+    (subs #?(:clj (.getPath (java.net.URL. uri-string))
              :cljs (.getPath (goog.Uri. uri-string)))
           1)))
 

--- a/test/bidi/bidi_test.cljc
+++ b/test/bidi/bidi_test.cljc
@@ -326,3 +326,6 @@
     (is (= {:handler :b} (match-route myroutes "/b")))
     (is (nil? (match-route myroutes "/a")))
     (is (nil? (match-route myroutes "/:b")))))
+
+(deftest invalid-uri-test
+  (is (= (match-route ["/blog/foo" 'foo] "<><>") nil)))


### PR DESCRIPTION
This fixes an invalid URI message when urls contains symbols which are
valid in URLs, but not in a URI, e.g. `<`. Also adds a regression test
for that.