### PR TITLE
bidi: provide path-for*, let path-for depend on it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: clojure
-lein: lein2
+lein: lein
 cache:
   directories:
     - $HOME/.m2

--- a/src/bidi/bidi.cljc
+++ b/src/bidi/bidi.cljc
@@ -388,14 +388,22 @@ actually a valid UUID (this is handled by the route matching logic)."
   [route path & {:as options}]
   (match-route* route path options))
 
-(defn path-for
+(defn path-for*
   "Given a route definition data structure, a handler and an option map, return a
   path that would route to the handler. The map must contain the values to any
   parameters required to create the path, and extra values are silently ignored."
-  [route handler & {:as params}]
+  [route handler params]
   (when (nil? handler)
     (throw (ex-info "Cannot form URI from a nil handler" {})))
   (unmatch-pair route {:handler handler :params params}))
+
+(defn path-for
+  "Given a route definition data structure, a handler and an unrolled option map,
+  return a path that would route to the handler. The map must contain the values
+  to any parameters required to create the path, and extra values are silently
+  ignored."
+  [route handler & {:as params}]
+  (path-for* route handler params))
 
 ;; --------------------------------------------------------------------------------
 ;; Route seqs


### PR DESCRIPTION
This provides a close cousin of `match-route*` to avoid forcing library consumers to use `unmatch-pair` which is less legible in calling code.