### PR TITLE
Add support for HTML5 mode to router

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 ;; Copyright © 2014, JUXT LTD.
 
-(defproject bidi "2.1.3"
+(defproject bidi "2.1.3-SNAPSHOT"
   :description "Bidirectional URI routing"
   :url "https://github.com/juxt/bidi"
 

--- a/src/bidi/router.cljs
+++ b/src/bidi/router.cljs
@@ -3,7 +3,8 @@
             [goog.History :as h]
             [goog.events :as e]
             [clojure.string :as s])
-  (:import [goog History]))
+  (:import goog.History
+           goog.history.Html5History))
 
 (defprotocol Router
   (set-location! [_ location])
@@ -22,6 +23,7 @@
     routes :- a Bidi route structure
     on-navigate :- 0-arg function, accepting a Location
     default-location :- Location to default to if the current token doesn't match a route
+    mode :- Bootstrap the router in either :legacy or :html5 mode
 
   Returns :- Router
 
@@ -34,16 +36,19 @@
                                           \"/page2\" ::page2}]
                                    {:on-navigate (fn [location]
                                                    (reset! !location location))
-                                    :default-location {:handler ::home-page}})]
+                                    :default-location {:handler ::home-page}
+                                    :mode html5})]
 
       ...
 
       (br/set-location! router {:handler ::page2}))"
 
-  [routes {:keys [on-navigate default-location]
-           :or {on-navigate (constantly nil)}}]
+  [routes {:keys [on-navigate default-location mode]
+           :or {on-navigate (constantly nil) mode :legacy}}]
 
-  (let [history (History.)]
+  (let [history (case mode
+                  :legacy (History.)
+                  :html5 (Html5History.))]
     (.setEnabled history true)
 
     (letfn [(token->location [token]


### PR DESCRIPTION
This pull request adds support for HTML5 mode to the router.

The API change is small. `start-router!` now takes an additional named argument, `mode`, which defaults to `:legacy` but may be optionally set to `:html5`. Since `:legacy` is the default, this should not be a breaking change.

In a future major version release, it may be prudent to change the default to `:html5`, since most new SPAs seem to be taking advantage of HTML5 mode.