### PR TITLE
Support ->Resources and ->ResourcesMaybe with make-handler

### DIFF
--- a/src/bidi/ring.cljc
+++ b/src/bidi/ring.cljc
@@ -101,7 +101,12 @@
                           {:status 404}))
                       (wrap-content-type options))))))
      (unresolve-handler [this m]
-       (when (= this (:handler m)) ""))))
+       (when (= this (:handler m)) ""))
+     Ring
+     (request [f req m]
+       (if-let [res (resource-response (str (:prefix options) (:uri req)))]
+         res
+         {:status 404}))))
 
 #?(:clj
    (defn resources [options]
@@ -127,7 +132,12 @@
                               (fn [req] (resource-response (str (:prefix options) path)))
                               (wrap-content-type options)))))))
      (unresolve-handler [this m]
-       (when (= this (:handler m)) ""))))
+       (when (= this (:handler m)) ""))
+     Ring
+     (request [f req m]
+       (let [path (str (:prefix options) (:uri req))]
+         (when (io/resource path)
+           (resource-response path))))))
 
 #?(:clj
    (defn resources-maybe [options]


### PR DESCRIPTION
I updated the `Resources` and `ResourcesMaybe` records so they implement Bidi's `Ring` protocol. This means that `->Resources` is compatible with `make-handler`.

For more context, see issue #99.

This commit deserves a thorough code review – I'm a new Clojure dev, and not particularly familiar with the internals of Bidi. Still, it seems to work fine on my side. Also, wasn't sure about the best way to test this, but can dig deeper if that's requirement. 