### PR TITLE
accept all uuids which Java and JavaScript will accept

### DIFF
--- a/src/bidi/bidi.cljc
+++ b/src/bidi/bidi.cljc
@@ -154,7 +154,7 @@ actually a valid UUID (this is handled by the route matching logic)."
     (condp = this
      keyword "[A-Za-z]+[A-Za-z0-9\\*\\+\\!\\-\\_\\?\\.]*(?:%2F[A-Za-z]+[A-Za-z0-9\\*\\+\\!\\-\\_\\?\\.]*)?"
      long "-?\\d{1,19}"
-     uuid "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}"
+     uuid "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
      :otherwise (throw (ex-info (str "Unidentified function qualifier to pattern segment: " this) {}))))
   (transform-param [this]
     (condp = this

--- a/test/bidi/bidi_test.cljc
+++ b/test/bidi/bidi_test.cljc
@@ -211,9 +211,14 @@
     (is (= (path-for routes :z :id #uuid "649a50e8-0342-47af-894e-27eefea83ca9")
            "/foo/649a50e8-0342-47af-894e-27eefea83ca9/bar"))
 
+    (is (= (:route-params (match-route routes "/foo/00000000-0000-0000-0000-000000000000"))
+           {:id #uuid "00000000-0000-0000-0000-000000000000"}))
+    (is (= (:route-params (match-route routes "/foo/649a50e8-0342-47af-c94e-27eefea83ca9"))
+           {:id #uuid "649a50e8-0342-47af-c94e-27eefea83ca9"}))
+    (is (= (:route-params (match-route routes "/foo/649a50e8-0342-67af-894e-27eefea83ca9"))
+           {:id #uuid "649a50e8-0342-67af-894e-27eefea83ca9"}))
+
     (testing "invalid uuids"
-      (is (nil? (match-route routes "/foo/649a50e8-0342-67af-894e-27eefea83ca9")))
-      (is (nil? (match-route routes "/foo/649a50e8-0342-47af-c94e-27eefea83ca9")))
       (is (nil? (match-route routes "/foo/649a50e8034247afc94e27eefea83ca9")))
       (is (nil? (match-route routes "/foo/1012301231111111111111111111"))))))
 


### PR DESCRIPTION
Accept UUIDs the same way Java does

Some UUID parameters are not matched, most noticeably the "nil" UUID consisting of only zeros. In addition, both Java (and e.g. .NET) and ClojureScript core accept a lot wider variety of "UUIDs", some of which are technically not correct.

This commit proposes to bring the bidi implementation in line with what Java accepts, which is any string with 5 parts separated by hyphens, which each part of a specific length and only hex characters.

Fixes #159