### PR TITLE
add circleci config version 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,33 @@
+version: 2
+
+jobs:
+  test:
+    docker:
+      - image: circleci/clojure:lein-2.8.1
+
+    # this is needed because inside the docker container $TERM
+    # is not defined
+    environment:
+      - TERM: dumb
+
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - clj-deps-{{ checksum "project.clj" }}
+
+      - run: lein deps
+      - run: lein test
+      - save_cache:
+          paths:
+            - ~/.m2/repository
+            - ~/.lein
+
+          key: clj-deps-{{ checksum "project.clj" }}
+
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - test

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-test:
-  override:
-    - 'lein test'


### PR DESCRIPTION
New CircleCi config version 2.0

I noticed the build failing on circle-ci. This add the new 2.0 config to have all tests run correctly including caching.