### PR TITLE
Support symbols in TaggedMatch

### DIFF
--- a/src/bidi/bidi.cljc
+++ b/src/bidi/bidi.cljc
@@ -508,7 +508,7 @@ actually a valid UUID (this is handled by the route matching logic)."
   (resolve-handler [this m]
     (resolve-handler matched (assoc m :tag tag)))
   (unresolve-handler [this m]
-    (if (and (keyword? (:handler m)) (= tag (:handler m)))
+    (if (and (ident? (:handler m)) (= tag (:handler m)))
       ""
       (unresolve-handler matched m)))
   RouteSeq


### PR DESCRIPTION
Especially since the introduction of `:as-alias` it can be useful to support symbols (rather than only keywords) as identifiers with `bidi.bidi/tag`, eg. one can refer to a view using a qualified symbol pointing to its definition.

Note: if using this pattern in a cljc project, one should be aware of https://clojure.atlassian.net/browse/CLJS-3399